### PR TITLE
Docker ps updates to lab guide

### DIFF
--- a/Plus/labs/lab1/readme.md
+++ b/Plus/labs/lab1/readme.md
@@ -122,7 +122,7 @@ Visual Studio Code | Docker
 
 1. Open the Workshop folder with Visual Studio Code, so you can read and edit the files provided.
 
-    >**NOTE:** If you are not using F5 provided UDF environment then please perform the optional steps mentioned above that covers downloading NGINX Plus license files before jumping to next Step.
+    >**NOTE:** If you are not using F5 provided UDF environment then please perform the optional steps mentioned above that covers downloading NGINX Plus license files before jumping to next Step. If you are using F5 provide udf environment then the jumphost already has these license files placed in correct folders.
 
 
 1. Using the Visual Studio Terminal, set the `JWT` environment variable with your `labs/nginx-repo.jwt` license file. This is required to pull the NGINX Plus container images from the NGINX Private Registry referenced in the dockerfile.

--- a/Plus/labs/lab1/readme.md
+++ b/Plus/labs/lab1/readme.md
@@ -81,9 +81,8 @@ Visual Studio Code | Docker
 :-------------------------:|:-------------------------:
 ![VScode](media/vs-code-icon.png)  |![Docker](media/docker-icon.png)
 
-1. Open the Workshop folder with Visual Studio Code, or an IDE / text editor of your choice, so you can read and edit the files provided.
-
-    >**NOTE:** If you are using F5 provided UDF environment then jump to Step 5 and skip Step 2 - 4 as those steps cover downloading NGINX Plus license file which is already provided in the F5 UDF environment.
+<details>
+   <summary><b>Expand to see optional Steps if you are not using F5 provided UDF environment</b></summary>
 
 1. Download and copy your NGINX Plus license files to your computer.  There are 3 files provided, you will need all three files `.crt and .key and .jwt` files for this Workshop:
 
@@ -115,7 +114,16 @@ Visual Studio Code | Docker
 
     ```
 
-1. Using the Visual Studio Terminal, set the `JWT` environment variable with your nginx-repo.jwt license file. This is required to pull the NGINX Plus container images from the NGINX Private Registry referenced in the dockerfile.
+</details>
+
+<br/>
+
+1. Open the Workshop folder with Visual Studio Code, so you can read and edit the files provided.
+
+    >**NOTE:** If you are not using F5 provided UDF environment then please perform the optional steps mentioned above that covers downloading NGINX Plus license files before jumping to next Step.
+
+
+1. Using the Visual Studio Terminal, set the `JWT` environment variable with your `labs/nginx-repo.jwt` license file. This is required to pull the NGINX Plus container images from the NGINX Private Registry referenced in the dockerfile.
 
     ```bash
     export JWT=$(cat nginx-repo.jwt)

--- a/Plus/labs/lab1/readme.md
+++ b/Plus/labs/lab1/readme.md
@@ -81,6 +81,8 @@ Visual Studio Code | Docker
 :-------------------------:|:-------------------------:
 ![VScode](media/vs-code-icon.png)  |![Docker](media/docker-icon.png)
 
+<br/>
+
 <details>
    <summary><b>Expand to see optional Steps if you are not using F5 provided UDF environment</b></summary>
 

--- a/Plus/labs/lab1/readme.md
+++ b/Plus/labs/lab1/readme.md
@@ -122,7 +122,7 @@ Visual Studio Code | Docker
 
 1. Open the Workshop folder with Visual Studio Code, so you can read and edit the files provided.
 
-    >**NOTE:** If you are not using F5 provided UDF environment then please perform the optional steps mentioned above that covers downloading NGINX Plus license files before jumping to next Step. If you are using F5 provide udf environment then the jumphost already has these license files placed in correct folders.
+    >**NOTE:** If you are not using F5 provided UDF environment then please perform the optional steps mentioned above that covers downloading NGINX Plus license files before jumping to next Step. If you are using F5 provide UDF environment then the jumphost already has these license files placed in correct folders.
 
 
 1. Using the Visual Studio Terminal, set the `JWT` environment variable with your `labs/nginx-repo.jwt` license file. This is required to pull the NGINX Plus container images from the NGINX Private Registry referenced in the dockerfile.

--- a/Plus/labs/lab1/readme.md
+++ b/Plus/labs/lab1/readme.md
@@ -165,10 +165,10 @@ Visual Studio Code | Docker
 
    >If you encounter any errors during the Nginx Plus build process, or starting the containers, you must fix them before proceeding.  The most common errors are related to the nginx-repo files missing or expired or invalid.
 
-1. Verify your `lab1-nginx-plus` container is up and running:
+1. Verify your `nginx-plus` container is up and running:
 
     ```bash
-    docker ps
+    docker ps | grep nginx-plus
     ```
 
     ```bash

--- a/Plus/labs/lab2/readme.md
+++ b/Plus/labs/lab2/readme.md
@@ -135,7 +135,7 @@ Go ahead and try some of these NGINX commands in your nginx-plus container now, 
 1. Verify your `nginx-plus:workshop` container is up and running:
 
     ```bash
-    docker ps
+    docker ps | grep nginx-plus
 
     ```
 

--- a/Plus/labs/lab4/readme.md
+++ b/Plus/labs/lab4/readme.md
@@ -109,7 +109,7 @@ For this lab you will run 4 Docker containers.  The first one will be used as an
 1. Verify all four containers are running:
 
     ```bash
-    docker ps
+    docker ps | grep -E 'nginx-plus|web'
 
     ```
 

--- a/Plus/labs/lab5/readme.md
+++ b/Plus/labs/lab5/readme.md
@@ -114,7 +114,7 @@ NGINX Plus is the `Commercial version of NGINX`, adding additional Enterprise fe
 1. Verify all four containers are running:
 
     ```bash
-    docker ps
+    docker ps | grep -E 'nginx-plus|web'
 
     ```
 

--- a/Plus/labs/lab6/readme.md
+++ b/Plus/labs/lab6/readme.md
@@ -163,7 +163,7 @@ As part of your Dockerfile, your NGINX Plus container already has the added `NGI
 1. Verify these 2 containers are running.
 
     ```bash
-    docker ps -a
+    docker ps | grep -E 'prometheus|grafana'
 
     ```
 
@@ -172,8 +172,6 @@ As part of your Dockerfile, your NGINX Plus container already has the added `NGI
     CONTAINER ID   IMAGE                   COMMAND                  CREATED          STATUS          PORTS                                                                                      NAMES
     8a61c66fc511   prom/prometheus         "/bin/prometheus --c…"   36 minutes ago   Up 36 minutes   0.0.0.0:9090->9090/tcp                                                                     prometheus
     4d38710ed4ec   grafana/grafana         "/run.sh"                36 minutes ago   Up 36 minutes   0.0.0.0:3000->3000/tcp                                                                     grafana
-
-    ...snip
 
     ```
 


### PR DESCRIPTION
Below are the doc updates covered in this PR:

1.  Updated all `docker ps` commands to add `grep` command so that it only shows the containers that are relevant for the workshop. Since we are using the super jumphost, running `docker ps` without `grep` also shows the other four containers related to the jumphost.
1. Made use of the collapsible section to collapse the license download steps in lab1.